### PR TITLE
Fix default text and focus in NumberOption | CHUI-64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.7.2] - 2020-06-22
+### Fixed
+- Remove default text `-` when reactivating NumberOption.
+- Focus NumberOption input when after activating it.
+
 ## [0.7.1] - 2020-06-02
 ### Added
 - Prop `hiddenFields` to `PlaceDetails` component.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Fixed
 - Remove default text `-` when reactivating NumberOption.
-- Focus NumberOption input when after activating it.
+- Focus NumberOption input after activating it.
 
 ## [0.7.1] - 2020-06-02
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-## [0.7.2] - 2020-06-22
 ### Fixed
 - Remove default text `-` when reactivating NumberOption.
 - Focus NumberOption input when after activating it.

--- a/react/components/NumberOption.tsx
+++ b/react/components/NumberOption.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useRef } from 'react'
 import { useAddressContext } from 'vtex.address-context/AddressContext'
 import { Input, Checkbox } from 'vtex.styleguide'
 import { FormattedMessage, useIntl, defineMessages } from 'react-intl'
@@ -38,15 +38,22 @@ interface Props {
 
 const NumberOption: React.FC<Props> = ({ showCheckbox, ...props }) => {
   const intl = useIntl()
+  const inputNode = useRef<HTMLInputElement>(null);
   const { setAddress } = useAddressContext()
   const [disabled, setDisabled] = useState(false)
 
   const onCheckboxChange = () => {
     setAddress((prevAddress: Address) => ({
       ...prevAddress,
-      number: disabled ? '-' : intl.formatMessage(messages.wn),
+      number: disabled ? '' : intl.formatMessage(messages.wn),
     }))
     setDisabled(!disabled)
+    
+    setTimeout(() => {
+      if (inputNode.current !== null) {        
+        inputNode.current.focus();
+      }
+    }, 0);
   }
 
   const checkboxProps = {
@@ -60,7 +67,7 @@ const NumberOption: React.FC<Props> = ({ showCheckbox, ...props }) => {
   return (
     <div className="flex">
       <div className="flex-auto">
-        <Input {...props} disabled={disabled || props.disabled} />
+        <Input ref={inputNode} {...props} disabled={disabled || props.disabled} />
       </div>
       {showCheckbox && (
         <div className="flex-none h-regular ml5 mt7 flex items-center">

--- a/react/components/NumberOption.tsx
+++ b/react/components/NumberOption.tsx
@@ -50,9 +50,7 @@ const NumberOption: React.FC<Props> = ({ showCheckbox, ...props }) => {
     setDisabled(!disabled)
     
     setTimeout(() => {
-      if (inputNode.current !== null) {        
-        inputNode.current.focus()
-      }
+      inputNode.current?.focus()
     }, 0)
   }
 

--- a/react/components/NumberOption.tsx
+++ b/react/components/NumberOption.tsx
@@ -38,7 +38,7 @@ interface Props {
 
 const NumberOption: React.FC<Props> = ({ showCheckbox, ...props }) => {
   const intl = useIntl()
-  const inputNode = useRef<HTMLInputElement>(null);
+  const inputNode = useRef<HTMLInputElement>(null)
   const { setAddress } = useAddressContext()
   const [disabled, setDisabled] = useState(false)
 
@@ -51,9 +51,9 @@ const NumberOption: React.FC<Props> = ({ showCheckbox, ...props }) => {
     
     setTimeout(() => {
       if (inputNode.current !== null) {        
-        inputNode.current.focus();
+        inputNode.current.focus()
       }
-    }, 0);
+    }, 0)
   }
 
   const checkboxProps = {

--- a/react/components/NumberOption.tsx
+++ b/react/components/NumberOption.tsx
@@ -38,7 +38,7 @@ interface Props {
 
 const NumberOption: React.FC<Props> = ({ showCheckbox, ...props }) => {
   const intl = useIntl()
-  const inputNode = useRef<HTMLInputElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
   const { setAddress } = useAddressContext()
   const [disabled, setDisabled] = useState(false)
 
@@ -50,7 +50,7 @@ const NumberOption: React.FC<Props> = ({ showCheckbox, ...props }) => {
     setDisabled(!disabled)
     
     setTimeout(() => {
-      inputNode.current?.focus()
+      inputRef.current?.focus()
     }, 0)
   }
 
@@ -65,7 +65,7 @@ const NumberOption: React.FC<Props> = ({ showCheckbox, ...props }) => {
   return (
     <div className="flex">
       <div className="flex-auto">
-        <Input ref={inputNode} {...props} disabled={disabled || props.disabled} />
+        <Input ref={inputRef} {...props} disabled={disabled || props.disabled} />
       </div>
       {showCheckbox && (
         <div className="flex-none h-regular ml5 mt7 flex items-center">


### PR DESCRIPTION
#### What problem is this solving?

The NumberOption component was inserting a `-` in input value when unchecking the checkbox. The appropriate behavior is to focus the input without any value in it, that's what this PR do.

#### How should this be manually tested?

[Workspace](https://fixplacenumberinput--checkoutio.myvtexdev.com/)

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
