### PR TITLE
Fix DeviceCoordinates reverse geocode query execution.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Add onSuccess prop to DeviceCoordinates.
+- Fix reverse geocode execution in DeviceCoordinates.
 
 ## [0.7.1] - 2020-06-02
 ### Added


### PR DESCRIPTION
#### What problem is this solving?

The reverse geocode query wasn't executing properly. It was necessary to execute onSuccess function after executing the query for the state machine to be triggered.

#### How should this be manually tested?

[Workspace](https://chui63--checkoutio.myvtex.com/)
You should proceed to checkout and ask it to get your current location in shipping step.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

This fix was made through all these repositories:
[checkout-shipping](https://github.com/vtex-apps/checkout-shipping/pull/10)
place-components
[places-graphql](https://github.com/vtex-apps/places-graphql/pull/4)
