### PR TITLE
CHK-152: Add tests and fix popover bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ yarn-error.log
 *.orig
 package-lock.json
 .editorconfig
+react/coverage/

--- a/react/LocationSearch.tsx
+++ b/react/LocationSearch.tsx
@@ -85,7 +85,7 @@ const LocationSearch: React.FC<LocationSearchProps> = ({
               </div>
             }
             suffix={
-              searchTerm.trim().length && (
+              searchTerm.trim().length ? (
                 <span
                   data-testid="location-search-clear"
                   role="button"
@@ -98,7 +98,7 @@ const LocationSearch: React.FC<LocationSearchProps> = ({
                 >
                   <IconClear />
                 </span>
-              )
+              ) : null
             }
             value={searchTerm}
             onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
@@ -107,41 +107,43 @@ const LocationSearch: React.FC<LocationSearchProps> = ({
             onKeyDown={handleKeyDown}
           />
         </div>
-        <ComboboxPopover
-          position={(_targetRect, popoverRect) =>
-            positionMatchWidth(
-              inputWrapperRef.current?.getBoundingClientRect(),
-              popoverRect
-            )
-          }
-        >
-          {addresses.length > 0 ? (
-            <>
-              <ComboboxList>
-                {addresses.map((address, index) => (
-                  <ComboboxOption value={address.description} key={index}>
-                    <PlaceIcon className="flex flex-shrink-0 mr4 c-muted-1" />
-                    {renderSuggestionText(address)}
-                  </ComboboxOption>
-                ))}
-              </ComboboxList>
-              {renderEngineLogo && (
-                <div className="flex flex-row-reverse">
-                  <div className="mt3 mb1 mh5">{renderEngineLogo()}</div>
+        {searchTerm.trim().length ? (
+          <ComboboxPopover
+            position={(_targetRect, popoverRect) =>
+              positionMatchWidth(
+                inputWrapperRef.current?.getBoundingClientRect(),
+                popoverRect
+              )
+            }
+          >
+            {addresses.length > 0 ? (
+              <>
+                <ComboboxList>
+                  {addresses.map((address, index) => (
+                    <ComboboxOption value={address.description} key={index}>
+                      <PlaceIcon className="flex flex-shrink-0 mr4 c-muted-1" />
+                      {renderSuggestionText(address)}
+                    </ComboboxOption>
+                  ))}
+                </ComboboxList>
+                {renderEngineLogo && (
+                  <div className="flex flex-row-reverse">
+                    <div className="mt3 mb1 mh5">{renderEngineLogo()}</div>
+                  </div>
+                )}
+              </>
+            ) : (
+              <div className="flex items-center pv3 ph5">
+                <div className="flex flex-shrink-0 mr4 c-muted-3">
+                  <IconWarning />
                 </div>
-              )}
-            </>
-          ) : (
-            <div className="flex items-center pv3 ph5">
-              <div className="flex flex-shrink-0 mr4 c-muted-3">
-                <IconWarning />
+                <div className="truncate c-muted-2 fw6">
+                  <FormattedMessage id="place-components.label.autocompleteAddressFail" />
+                </div>
               </div>
-              <div className="truncate c-muted-2 fw6">
-                <FormattedMessage id="place-components.label.autocompleteAddressFail" />
-              </div>
-            </div>
-          )}
-        </ComboboxPopover>
+            )}
+          </ComboboxPopover>
+        ) : null}
       </Combobox>
     </div>
   )

--- a/react/__fixtures__/fixtures.tsx
+++ b/react/__fixtures__/fixtures.tsx
@@ -1,6 +1,8 @@
 import { Address } from 'vtex.checkout-graphql'
 import { AddressRules } from 'vtex.address-context/react/types'
 
+import { Suggestion } from '../LocationSearch'
+
 export const completeAddress: Address = {
   street: 'Av. Belgrano',
   number: '2248',
@@ -48,6 +50,30 @@ export const sampleAddress: Address = {
   receiverName: null,
   reference: null,
 }
+
+export const getFewAddresses = (searchTerm: string): Suggestion[] =>
+  [
+    {
+      description: 'Praia de Botafogo, 300, Botafogo, Rio de Janeiro, RJ',
+      mainText: 'Praia de Botafogo, 300',
+      mainTextMatchInterval: {
+        offset: 0,
+        size: 0,
+      },
+      secondaryText: 'Botafogo, Rio de Janeiro, RJ',
+    },
+    {
+      description: 'Praia de Botafogo, 200, Botafogo, Rio de Janeiro, RJ',
+      mainText: 'Praia de Botafogo, 200',
+      mainTextMatchInterval: {
+        offset: 0,
+        size: 0,
+      },
+      secondaryText: 'Botafogo, Rio de Janeiro, RJ',
+    },
+  ].filter(
+    suggestion => searchTerm.length && suggestion.mainText.includes(searchTerm)
+  )
 
 export const braRules: AddressRules = {
   BRA: {

--- a/react/__tests__/LocationSearch.test.tsx
+++ b/react/__tests__/LocationSearch.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@vtex/test-tools/react'
+
+import LocationSearch from '../LocationSearch'
+import { getFewAddresses } from '../__fixtures__/fixtures'
+
+const UNTABABBLE = -1
+
+describe('Location Search', () => {
+  it('should be able to select a suggested address when a search term is found', async () => {
+    render(<LocationSearch getAddresses={getFewAddresses} />)
+
+    const input = screen.getByLabelText(
+      /Address and house number/i
+    ) as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'Praia de Botafogo' } })
+
+    expect(
+      await screen.findByText('Praia de Botafogo, 200')
+    ).toBeInTheDocument()
+    expect(
+      await screen.findByText('Praia de Botafogo, 300')
+    ).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('Praia de Botafogo, 200'))
+    expect(input).toHaveValue(
+      'Praia de Botafogo, 200, Botafogo, Rio de Janeiro, RJ'
+    )
+  })
+
+  it('should be able to clear the input when something is typed', () => {
+    render(<LocationSearch getAddresses={getFewAddresses} />)
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+
+    const input = screen.getByLabelText(
+      /Address and house number/i
+    ) as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'Praia de Botafogo' } })
+    const button = screen.getByRole('button')
+    expect(button.tabIndex).toBe(UNTABABBLE)
+
+    fireEvent.click(button)
+
+    expect(input).toHaveValue('')
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+
+    fireEvent.change(input, { target: { value: 'Praia de Botafogo' } })
+    fireEvent.keyDown(input, { key: 'Escape', code: 'Escape' })
+
+    expect(input).toHaveValue('')
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  it('should display failure message when the search term is not found', () => {
+    render(<LocationSearch getAddresses={() => []} />)
+
+    const input = screen.getByLabelText(
+      /Address and house number/i
+    ) as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'Praia de Botafogo' } })
+    expect(screen.getByText('No results found')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
#### What problem is this solving?

Add few tests to the new component and fixes a bug where the popover would be open even though there were no input at all (that was raising a warning from React Testing Library, as the popover wasn't closed when the test ended).

#### How should this be manually tested?

1. Open this branch with `git fetch origin test/location-search && git switch test/location-search`
2. Run `cd react && yarn && yarn test __tests__/LocationSearch.test.tsx`
3. `3` tests out of `3` should pass

#### Notes

A warning is raised when running the tests:

```
$ vtex-test-tools test __tests__/LocationSearch.test.tsx
  console.error node_modules/@vtex/test-tools/node_modules/react/cjs/react.development.js:167
    Warning: forwardRef render functions do not support propTypes or defaultProps. Did you accidentally pass a React component?
```

How to fix that?