### PR TITLE
CHK-402: Adapt LocationSearch component to use Geolocation Provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Prop `hiddenFields` to `PlaceDetails` component.
 
 ### Changed
-- `LocationCountry` now shows the country flag alognside their name.
+- `LocationCountry` now shows the country flag alongside their name.
 
 ### Fixed
 - `LocationCountry` shown with only one country.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- `LocationSearch` component now send queries to `vtex.geolocation-graphql-interface` instead of `places-graphql`.
 
 ## [0.10.0] - 2020-09-01
 ### Added
-- `LocationSearch`
+- `LocationSearch`.
 
 ## [0.9.1] - 2020-08-18
 

--- a/manifest.json
+++ b/manifest.json
@@ -17,7 +17,8 @@
     "vtex.checkout-graphql": "0.x",
     "vtex.country-flags": "0.x",
     "vtex.places-graphql": "0.x",
-    "vtex.styleguide": "9.x"
+    "vtex.styleguide": "9.x",
+    "vtex.geolocation-graphql-interface": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/AddressForm.tsx
+++ b/react/AddressForm.tsx
@@ -203,13 +203,7 @@ const AddressForm: React.FC<AddressFormProps> = ({
 
               let fragmentElement = null
 
-              const {
-                maxLength,
-                autoComplete,
-                required,
-                label,
-                options,
-              } = field
+              const { maxLength, autoComplete, required, label } = field
 
               const handleChange: React.ChangeEventHandler<
                 HTMLInputElement | HTMLSelectElement
@@ -220,7 +214,7 @@ const AddressForm: React.FC<AddressFormProps> = ({
                 }))
               }
 
-              const value = address[fragment.name]!
+              const value = address[fragment.name] as string
 
               const commonProps = {
                 label: intl.formatMessage(
@@ -232,7 +226,7 @@ const AddressForm: React.FC<AddressFormProps> = ({
                 ...(maxLength && { maxLength }),
                 ...(autoComplete && { autoComplete }),
                 ...(required &&
-                address[fragment.name]!.length === 0 &&
+                address[fragment.name]?.length === 0 &&
                 fieldsMeta[fragment.name]?.blurred
                   ? {
                       errorMessage: intl.formatMessage(messages.fieldRequired),

--- a/react/LocationCountry.tsx
+++ b/react/LocationCountry.tsx
@@ -37,12 +37,6 @@ interface Option {
   value: string
 }
 
-const sortOptionsByLabel = (options: Option[]) => {
-  return options
-    .slice()
-    .sort((a: Option, b: Option) => a.label.localeCompare(b.label))
-}
-
 const renderCountryFlagWithName = ({
   country,
   name,

--- a/react/LocationSearch.tsx
+++ b/react/LocationSearch.tsx
@@ -10,7 +10,7 @@ import {
 import { positionMatchWidth } from '@reach/popover'
 import { useAddressContext } from 'vtex.address-context/AddressContext'
 import { useLazyQuery } from 'react-apollo'
-import { Address, AddressSuggestion } from 'vtex.places-graphql'
+import { Address, AddressSuggestion } from 'vtex.geolocation-graphql-interface'
 
 import SUGGEST_ADDRESSES from './graphql/suggestAddresses.graphql'
 import GET_ADDRESS_BY_EXTERNAL_ID from './graphql/getAddressByExternalId.graphql'

--- a/react/LocationSearch.tsx
+++ b/react/LocationSearch.tsx
@@ -10,7 +10,13 @@ import {
 import { positionMatchWidth } from '@reach/popover'
 import { useAddressContext } from 'vtex.address-context/AddressContext'
 import { useLazyQuery } from 'react-apollo'
-import { Address, AddressSuggestion } from 'vtex.geolocation-graphql-interface'
+import {
+  Address,
+  AddressSuggestion,
+  Query,
+  QueryGetAddressByExternalIdArgs,
+  QuerySuggestAddressesArgs,
+} from 'vtex.geolocation-graphql-interface'
 
 import SUGGEST_ADDRESSES from './graphql/suggestAddresses.graphql'
 import GET_ADDRESS_BY_EXTERNAL_ID from './graphql/getAddressByExternalId.graphql'
@@ -40,17 +46,19 @@ const useDebouncedValue = (value: string, delayInMs: number) => {
   return debouncedValue
 }
 
-const renderSuggestionText = (suggestion: AddressSuggestion) => {
-  const { mainText } = suggestion
-  const { offset, length } = suggestion.mainTextMatchInterval
+const renderSuggestionText = ({
+  mainText,
+  mainTextMatchInterval: { offset, length },
+  secondaryText,
+}: AddressSuggestion) => {
   return (
     <div className="truncate c-muted-2">
       <span className="c-on-base">
         {mainText.substr(0, offset)}
         <span className="b">{mainText.substr(offset, length)}</span>
-        {mainText.substr(length + offset)}
+        {mainText.substr(offset + length)}
       </span>{' '}
-      <span>{suggestion.secondaryText}</span>
+      <span>{secondaryText}</span>
     </div>
   )
 }
@@ -79,11 +87,13 @@ const LocationSearch: React.FC<LocationSearchProps> = ({
       error: suggestAddressesError,
       loading: suggestAddressesLoading,
     },
-  ] = useLazyQuery(SUGGEST_ADDRESSES)
+  ] = useLazyQuery<Query, QuerySuggestAddressesArgs>(SUGGEST_ADDRESSES)
   const [
     executeGetAddressByExternalId,
     { data: getAddressByExternalIdData, error: getAddressByExternalIdError },
-  ] = useLazyQuery(GET_ADDRESS_BY_EXTERNAL_ID)
+  ] = useLazyQuery<Query, QueryGetAddressByExternalIdArgs>(
+    GET_ADDRESS_BY_EXTERNAL_ID
+  )
 
   useEffect(() => {
     if (debouncedSearchTerm.trim().length) {
@@ -100,7 +110,7 @@ const LocationSearch: React.FC<LocationSearchProps> = ({
       setSuggestions(suggestAddressesData.suggestAddresses)
     }
     if (suggestAddressesError) {
-      console.warn(suggestAddressesError.message)
+      console.error(suggestAddressesError.message)
     }
   }, [suggestAddressesData, suggestAddressesError, setSuggestions])
 
@@ -110,7 +120,7 @@ const LocationSearch: React.FC<LocationSearchProps> = ({
       onSelectAddress?.(getAddressByExternalIdData.getAddressByExternalId)
     }
     if (getAddressByExternalIdError) {
-      console.warn(getAddressByExternalIdError.message)
+      console.error(getAddressByExternalIdError.message)
     }
   }, [
     getAddressByExternalIdData,
@@ -127,11 +137,16 @@ const LocationSearch: React.FC<LocationSearchProps> = ({
   }
 
   const handleAddressSelection = (selectedAddress: string) => {
-    setSearchTerm(selectedAddress)
     const id = suggestions.find(
       address => address.description === selectedAddress
     )?.externalId
-    executeGetAddressByExternalId({ variables: { id } })
+
+    if (id) {
+      setSearchTerm(selectedAddress)
+      executeGetAddressByExternalId({ variables: { id } })
+    } else {
+      console.error(`${selectedAddress} was not found`)
+    }
   }
 
   return (

--- a/react/LocationSelect.tsx
+++ b/react/LocationSelect.tsx
@@ -3,6 +3,7 @@ import { useAddressContext } from 'vtex.address-context/AddressContext'
 import { Dropdown } from 'vtex.styleguide'
 import { FormattedMessage, defineMessages } from 'react-intl'
 import { Address } from 'vtex.checkout-graphql'
+import { AddressFields } from 'vtex.address-context/types'
 
 const messages = defineMessages({
   province: {
@@ -45,7 +46,7 @@ const messages = defineMessages({
 
 const LocationSelect: React.FC = () => {
   const { address, setAddress, rules } = useAddressContext()
-  const countryRules = rules[address.country!]
+  const countryRules = rules[address.country as string]
 
   if (!countryRules?.locationSelect) {
     throw new Error(
@@ -55,7 +56,9 @@ const LocationSelect: React.FC = () => {
 
   const { countryData, fields } = countryRules.locationSelect
 
-  const addressFields = fields.map(field => address[field.name!])
+  const addressFields = fields.map(
+    field => address[field.name as AddressFields]
+  )
   const firstMissingIdx = addressFields.findIndex(field => !field)
   const completedFields =
     firstMissingIdx === -1
@@ -68,7 +71,7 @@ const LocationSelect: React.FC = () => {
 
     for (let i = 0; i < fields.length; ++i) {
       const field = fields[i]
-      const fieldValue = address[field.name!]
+      const fieldValue = address[field.name as AddressFields]
 
       if (typeof fieldValue !== 'string') {
         continue

--- a/react/PlaceDetails.tsx
+++ b/react/PlaceDetails.tsx
@@ -13,7 +13,7 @@ const PlaceDetails: React.FC<Props> = ({
   hiddenFields = [],
 }) => {
   const { address, rules } = useAddressContext()
-  const countryRules = rules[address.country!]
+  const countryRules = rules[address.country as string]
 
   if (!countryRules) {
     return null
@@ -46,7 +46,7 @@ const PlaceDetails: React.FC<Props> = ({
                 : undefined
 
             const addressValue = valueMask
-              ? msk(address[fragment.name]!, valueMask)
+              ? msk(address[fragment.name] as string, valueMask)
               : address[fragment.name]
 
             return (

--- a/react/components/NumberOption.tsx
+++ b/react/components/NumberOption.tsx
@@ -46,7 +46,7 @@ const NumberOption: React.FC<Props> = ({ showCheckbox, ...props }) => {
       number: disabled ? '' : intl.formatMessage(messages.wn),
     }))
     setDisabled(!disabled)
-    
+
     setTimeout(() => {
       inputRef.current?.focus()
     }, 0)
@@ -63,7 +63,11 @@ const NumberOption: React.FC<Props> = ({ showCheckbox, ...props }) => {
   return (
     <div className="flex">
       <div className="flex-auto">
-        <Input ref={inputRef} {...props} disabled={disabled || props.disabled} />
+        <Input
+          ref={inputRef}
+          {...props}
+          disabled={disabled || props.disabled}
+        />
       </div>
       {showCheckbox && (
         <div className="flex-none h-regular ml5 mt7 flex items-center">

--- a/react/graphql/getAddressByExternalId.graphql
+++ b/react/graphql/getAddressByExternalId.graphql
@@ -1,4 +1,4 @@
-query GetAddressByExternalId($id: String) {
+query GetAddressByExternalId($id: String!) {
   getAddressByExternalId(id: $id)
     @context(provider: "vtex.geolocation-graphql-interface") {
     addressId

--- a/react/graphql/getAddressByExternalId.graphql
+++ b/react/graphql/getAddressByExternalId.graphql
@@ -1,5 +1,6 @@
 query GetAddressByExternalId($id: String) {
-  getAddressByExternalId(id: $id) {
+  getAddressByExternalId(id: $id)
+    @context(provider: "vtex.geolocation-graphql-interface") {
     addressId
     addressType
     city

--- a/react/graphql/suggestAddresses.graphql
+++ b/react/graphql/suggestAddresses.graphql
@@ -1,5 +1,6 @@
 query SuggestAddresses($searchTerm: String) {
-  suggestAddresses(searchTerm: $searchTerm) {
+  suggestAddresses(searchTerm: $searchTerm)
+    @context(provider: "vtex.geolocation-graphql-interface") {
     description
     mainText
     mainTextMatchInterval {

--- a/react/graphql/suggestAddresses.graphql
+++ b/react/graphql/suggestAddresses.graphql
@@ -1,4 +1,4 @@
-query SuggestAddresses($searchTerm: String) {
+query SuggestAddresses($searchTerm: String!) {
   suggestAddresses(searchTerm: $searchTerm)
     @context(provider: "vtex.geolocation-graphql-interface") {
     description

--- a/react/package.json
+++ b/react/package.json
@@ -28,9 +28,9 @@
     "vtex.checkout-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-components@0.4.0/public/@types/vtex.checkout-components",
     "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.45.0/public/@types/vtex.checkout-graphql",
     "vtex.country-flags": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.country-flags@0.1.1/public/@types/vtex.country-flags",
-    "vtex.geolocation-graphql-interface": "https://w0geo--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.geolocation-graphql-interface@0.0.2+build1602857548/public/@types/vtex.geolocation-graphql-interface",
-    "vtex.places-graphql": "https://w0geo--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.places-graphql@0.3.0+build1602808301/public/@types/vtex.places-graphql",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.123.1/public/@types/vtex.render-runtime",
+    "vtex.geolocation-graphql-interface": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.geolocation-graphql-interface@0.0.3/public/@types/vtex.geolocation-graphql-interface",
+    "vtex.places-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.places-graphql@0.4.0/public/@types/vtex.places-graphql",
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.124.2/public/@types/vtex.render-runtime",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.133.0/public/@types/vtex.styleguide"
   },
   "version": "0.10.0"

--- a/react/package.json
+++ b/react/package.json
@@ -26,11 +26,12 @@
     "apollo-client": "^2.6.10",
     "vtex.address-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.address-context@0.3.0/public/@types/vtex.address-context",
     "vtex.checkout-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-components@0.4.0/public/@types/vtex.checkout-components",
-    "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.36.5/public/@types/vtex.checkout-graphql",
+    "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.45.0/public/@types/vtex.checkout-graphql",
     "vtex.country-flags": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.country-flags@0.1.1/public/@types/vtex.country-flags",
-    "vtex.places-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.places-graphql@0.2.1/public/@types/vtex.places-graphql",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.111.0/public/@types/vtex.render-runtime",
-    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.124.2/public/@types/vtex.styleguide"
+    "vtex.geolocation-graphql-interface": "https://w0geo--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.geolocation-graphql-interface@0.0.2+build1602857548/public/@types/vtex.geolocation-graphql-interface",
+    "vtex.places-graphql": "https://w0geo--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.places-graphql@0.3.0+build1602808301/public/@types/vtex.places-graphql",
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.123.1/public/@types/vtex.render-runtime",
+    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.133.0/public/@types/vtex.styleguide"
   },
   "version": "0.10.0"
 }

--- a/react/package.json
+++ b/react/package.json
@@ -28,7 +28,7 @@
     "vtex.checkout-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-components@0.4.0/public/@types/vtex.checkout-components",
     "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.45.0/public/@types/vtex.checkout-graphql",
     "vtex.country-flags": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.country-flags@0.1.1/public/@types/vtex.country-flags",
-    "vtex.geolocation-graphql-interface": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.geolocation-graphql-interface@0.0.3/public/@types/vtex.geolocation-graphql-interface",
+    "vtex.geolocation-graphql-interface": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.geolocation-graphql-interface@0.0.4/public/@types/vtex.geolocation-graphql-interface",
     "vtex.places-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.places-graphql@0.4.0/public/@types/vtex.places-graphql",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.124.2/public/@types/vtex.render-runtime",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.133.0/public/@types/vtex.styleguide"

--- a/react/typings/vtex.styleguide.d.ts
+++ b/react/typings/vtex.styleguide.d.ts
@@ -5,6 +5,10 @@ declare module 'vtex.styleguide' {
 
   export const Input: React.FC<any>
 
+  export const IconClear: React.FC<any>
+
+  export const IconWarning: React.FC<any>
+
   export const InputButton: React.FC<any>
 
   export const Spinner: React.FC<any>

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -6296,9 +6296,9 @@ vtex-tachyons@^3.2.0:
   version "0.1.1"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.country-flags@0.1.1/public/@types/vtex.country-flags#90f42d100c364aa8b549bd8b8c88c8dc9550686a"
 
-"vtex.geolocation-graphql-interface@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.geolocation-graphql-interface@0.0.3/public/@types/vtex.geolocation-graphql-interface":
-  version "0.0.3"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.geolocation-graphql-interface@0.0.3/public/@types/vtex.geolocation-graphql-interface#97a760cb855c05c1306b772c1c35ddd543262f81"
+"vtex.geolocation-graphql-interface@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.geolocation-graphql-interface@0.0.4/public/@types/vtex.geolocation-graphql-interface":
+  version "0.0.4"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.geolocation-graphql-interface@0.0.4/public/@types/vtex.geolocation-graphql-interface#81866c68eec0f4f6c0dc97f9fb6e1df16aff194a"
 
 "vtex.places-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.places-graphql@0.4.0/public/@types/vtex.places-graphql":
   version "0.4.0"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -1286,6 +1286,7 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
+
 "@reach/auto-id@0.10.5":
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/@reach/auto-id/-/auto-id-0.10.5.tgz#fa78c71ce2f565ebed1ad91a8d9a685176d23c48"
@@ -6295,17 +6296,17 @@ vtex-tachyons@^3.2.0:
   version "0.1.1"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.country-flags@0.1.1/public/@types/vtex.country-flags#90f42d100c364aa8b549bd8b8c88c8dc9550686a"
 
-"vtex.geolocation-graphql-interface@https://w0geo--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.geolocation-graphql-interface@0.0.2+build1602857548/public/@types/vtex.geolocation-graphql-interface":
-  version "0.0.2"
-  resolved "https://w0geo--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.geolocation-graphql-interface@0.0.2+build1602857548/public/@types/vtex.geolocation-graphql-interface#5ebd6c6c9a3df8e5ce34709a89771dd2f02678e4"
+"vtex.geolocation-graphql-interface@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.geolocation-graphql-interface@0.0.3/public/@types/vtex.geolocation-graphql-interface":
+  version "0.0.3"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.geolocation-graphql-interface@0.0.3/public/@types/vtex.geolocation-graphql-interface#97a760cb855c05c1306b772c1c35ddd543262f81"
 
-"vtex.places-graphql@https://w0geo--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.places-graphql@0.3.0+build1602808301/public/@types/vtex.places-graphql":
-  version "0.3.0"
-  resolved "https://w0geo--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.places-graphql@0.3.0+build1602808301/public/@types/vtex.places-graphql#15e1a9ff5f7f1fbbcf2c8703070b624fcf7afffe"
+"vtex.places-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.places-graphql@0.4.0/public/@types/vtex.places-graphql":
+  version "0.4.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.places-graphql@0.4.0/public/@types/vtex.places-graphql#19d8522f344c82c677b474829deb629583def399"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.123.1/public/@types/vtex.render-runtime":
-  version "8.123.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.123.1/public/@types/vtex.render-runtime#427325fde9f5dddfb7104e7605364c33e5f5fc6d"
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.124.2/public/@types/vtex.render-runtime":
+  version "8.124.2"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.124.2/public/@types/vtex.render-runtime#d535e94b7f0a1fe69c79a2cb107f8c4a227a8b79"
 
 "vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.133.0/public/@types/vtex.styleguide":
   version "9.133.0"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -6287,25 +6287,29 @@ vtex-tachyons@^3.2.0:
   version "0.4.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-components@0.4.0/public/@types/vtex.checkout-components#e944338bd1d7acaee7e32dacb0ffd2bc45aa5c9b"
 
-"vtex.checkout-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.36.5/public/@types/vtex.checkout-graphql":
-  version "0.36.5"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.36.5/public/@types/vtex.checkout-graphql#750e41dfe30b38dd15adaf353810e96e9309f4b6"
+"vtex.checkout-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.45.0/public/@types/vtex.checkout-graphql":
+  version "0.45.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.45.0/public/@types/vtex.checkout-graphql#93a92fe3cf000f3767d9f99cc955262ce2004f48"
 
 "vtex.country-flags@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.country-flags@0.1.1/public/@types/vtex.country-flags":
   version "0.1.1"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.country-flags@0.1.1/public/@types/vtex.country-flags#90f42d100c364aa8b549bd8b8c88c8dc9550686a"
 
-"vtex.places-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.places-graphql@0.2.1/public/@types/vtex.places-graphql":
-  version "0.2.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.places-graphql@0.2.1/public/@types/vtex.places-graphql#ca02f9676515458e537afc08658ec79e6b263a7b"
+"vtex.geolocation-graphql-interface@https://w0geo--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.geolocation-graphql-interface@0.0.2+build1602857548/public/@types/vtex.geolocation-graphql-interface":
+  version "0.0.2"
+  resolved "https://w0geo--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.geolocation-graphql-interface@0.0.2+build1602857548/public/@types/vtex.geolocation-graphql-interface#5ebd6c6c9a3df8e5ce34709a89771dd2f02678e4"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.111.0/public/@types/vtex.render-runtime":
-  version "8.111.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.111.0/public/@types/vtex.render-runtime#01b2ce53d1aa2a974f5229c61bd9c83b43a86d76"
+"vtex.places-graphql@https://w0geo--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.places-graphql@0.3.0+build1602808301/public/@types/vtex.places-graphql":
+  version "0.3.0"
+  resolved "https://w0geo--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.places-graphql@0.3.0+build1602808301/public/@types/vtex.places-graphql#15e1a9ff5f7f1fbbcf2c8703070b624fcf7afffe"
 
-"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.124.2/public/@types/vtex.styleguide":
-  version "9.124.2"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.124.2/public/@types/vtex.styleguide#23f1937bebae169c1d110594a4af3cc3ef05c601"
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.123.1/public/@types/vtex.render-runtime":
+  version "8.123.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.123.1/public/@types/vtex.render-runtime#427325fde9f5dddfb7104e7605364c33e5f5fc6d"
+
+"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.133.0/public/@types/vtex.styleguide":
+  version "9.133.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.133.0/public/@types/vtex.styleguide#1afb6bfeceee829a24d18afb672f1f05d64638ac"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
#### What problem is this solving?

`LocationSearch` component now send queries to `vtex.geolocation-graphql-interface` instead of `places-graphql`, which gives more flexibility by not bounding the `LocationSearch` component to a implementation.

#### How should this be manually tested?

1. [Workspace](https://w0geo--checkoutio.myvtex.com/cart/add?sku=289)
2. Go to the shipping step inside checkout
3. Type `rua nascimento silva, 107` in the input
4. Select the first suggestion. It should display delivery options

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/26108090/96290247-a9162080-0fbc-11eb-9292-14c6ab3e25c5.png)
