### PR TITLE
CHK-425: Update LocationInput to accept promise as result of onSuccess

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@
 
 - [ ] Updated `README.md`.
 - [ ] Updated `CHANGELOG.md`.
-- [ ] Linked this PR to a Clubhouse story (if applicable).
+- [ ] Linked this PR to a Jira story (if applicable).
 - [ ] Updated/created tests (important for bug fixes).
 - [ ] Deleted the workspace after merging this PR (if applicable).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Allow `onSuccess` to return a promise and wait for its fulfillment
+  before removing loading state.
+
+### Fixed
+- Postal code mask not applied on blur in `LocationInput` component.
 
 ## [0.11.0] - 2020-10-29
 ### Changed

--- a/messages/en.json
+++ b/messages/en.json
@@ -25,6 +25,7 @@
   "place-components.label.KOR": "Korea",
   "place-components.label.useCurrentLocation": "Use current location",
   "place-components.label.postalCode": "Postal Code",
+  "place-components.error.postalCode": "Inform a valid postal code.",
   "place-components.label.dontKnowPostalCode": "I don't know my postal code",
   "place-components.label.autocompleteAddress": "Address and house number",
   "place-components.label.autocompleteAddressFail": "No results found"

--- a/messages/es.json
+++ b/messages/es.json
@@ -25,6 +25,7 @@
   "place-components.label.KOR": "Corea del Sur",
   "place-components.label.useCurrentLocation": "Usar ubicación actual",
   "place-components.label.postalCode": "Código Postal",
+  "place-components.error.postalCode": "Ingresse un código postal válido.",
   "place-components.label.dontKnowPostalCode": "No sé mi código postal",
   "place-components.label.autocompleteAddress": "Dirección y número",
   "place-components.label.autocompleteAddressFail": "Sin resultados"

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -25,6 +25,7 @@
   "place-components.label.KOR": "Coreia do Sul",
   "place-components.label.useCurrentLocation": "Usar localização atual",
   "place-components.label.postalCode": "CEP",
+  "place-components.error.postalCode": "Informe um CEP válido.",
   "place-components.label.dontKnowPostalCode": "Não sei meu CEP",
   "place-components.label.autocompleteAddress": "Endereço e número",
   "place-components.label.autocompleteAddressFail": "Nenhum resultado encontrado"


### PR DESCRIPTION
#### What problem is this solving?

This PR updates the `LocationInput` component to accept a promise as the result of `onSuccess` callback, and also make it apply the country rule's `postalCode.mask` on the blur event. With the promise as a return value for `onSuccess`, we will now catch the errors it throws and show this error state in the input, alongside an error message.

#### How should this be manually tested?

[Workspace](https://lucas--checkoutio.myvtex.com/cart/add?sku=289).

You can see the updated component in the above workspace in the shipping calculator and at Checkout. The shipping calculator is using the new promise as a return of `onSuccess` to make the component show the loading state while we update the selected address in the orderForm with the result address, and if you enter an invalid postal code the component will show an error instead of happily proceeding to the next step.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

![loc-input](https://user-images.githubusercontent.com/10223856/97627784-9bc05380-1a0a-11eb-9ac5-e102d43dacd0.gif)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
