### PR TITLE
CHK-138: Add label to CountryLocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- `CountryLocation` label is now displayed.
+- `LocationCountry` label is now displayed.
+- Failure message will no longer show up when starting to type on `LocationSearch`.
+
+### Added
+- Label id prop for `LocationCountry`.
+- Loading state after selecting an address on `LocationSearch`.
 
 ## [0.13.0] - 2020-11-17
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `CountryLocation` label is now displayed.
 
 ## [0.13.0] - 2020-11-17
 ### Added

--- a/messages/en.json
+++ b/messages/en.json
@@ -27,6 +27,6 @@
   "place-components.label.postalCode": "Postal Code",
   "place-components.error.postalCode": "Inform a valid postal code.",
   "place-components.label.dontKnowPostalCode": "I don't know my postal code",
-  "place-components.label.autocompleteAddress": "Address and house number",
+  "place-components.label.autocompleteAddress": "Address (street, number, square...)",
   "place-components.label.autocompleteAddressFail": "No results found"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -27,6 +27,6 @@
   "place-components.label.postalCode": "Código Postal",
   "place-components.error.postalCode": "Ingresse un código postal válido.",
   "place-components.label.dontKnowPostalCode": "No sé mi código postal",
-  "place-components.label.autocompleteAddress": "Dirección y número",
+  "place-components.label.autocompleteAddress": "Dirección (calle, número, plaza...)",
   "place-components.label.autocompleteAddressFail": "Sin resultados"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -27,6 +27,6 @@
   "place-components.label.postalCode": "CEP",
   "place-components.error.postalCode": "Informe um CEP válido.",
   "place-components.label.dontKnowPostalCode": "Não sei meu CEP",
-  "place-components.label.autocompleteAddress": "Endereço e número",
+  "place-components.label.autocompleteAddress": "Endereço (rua, número, quadra...)",
   "place-components.label.autocompleteAddressFail": "Nenhum resultado encontrado"
 }

--- a/react/LocationCountry.tsx
+++ b/react/LocationCountry.tsx
@@ -50,7 +50,13 @@ const renderCountryFlagWithName = ({
   </>
 )
 
-const LocationCountry: React.FC = () => {
+interface LocationCountryProps {
+  labelId?: string
+}
+
+const LocationCountry: React.FC<LocationCountryProps> = ({
+  labelId = 'location-country',
+}) => {
   const intl = useIntl()
   const { address, setAddress, countries } = useAddressContext()
   const {
@@ -98,42 +104,55 @@ const LocationCountry: React.FC = () => {
   }
 
   return (
-    <ListboxInput
-      translate={undefined}
-      label={intl.formatMessage({ id: 'place-components.label.country' })}
-      value={country}
-      onChange={setCountry}
-    >
-      <ListboxButton>
-        {({ label }) =>
-          renderCountryFlagWithName({
-            country,
-            name: label,
-          })
-        }
-      </ListboxButton>
-      <ListboxPopover translate={undefined}>
-        <ListboxList>
-          {countries.map(countryCode => {
-            const name =
-              countryCode in messages
-                ? intl.formatMessage(
-                    messages[countryCode as keyof typeof messages]
-                  )
-                : countryCode
+    <>
+      <span
+        id={labelId}
+        className="vtex-input__label db mb3 w-100 c-on-base t-body"
+      >
+        {intl.formatMessage({ id: 'place-components.label.country' })}
+      </span>
+      <ListboxInput
+        translate={undefined}
+        aria-labelledby={labelId}
+        className="h-100"
+        value={country}
+        onChange={setCountry}
+      >
+        <ListboxButton>
+          {({ label }) =>
+            renderCountryFlagWithName({
+              country,
+              name: label,
+            })
+          }
+        </ListboxButton>
+        <ListboxPopover translate={undefined}>
+          <ListboxList>
+            {countries.map(countryCode => {
+              const name =
+                countryCode in messages
+                  ? intl.formatMessage(
+                      messages[countryCode as keyof typeof messages]
+                    )
+                  : countryCode
 
-            return (
-              <ListboxOption value={countryCode} label={name} key={countryCode}>
-                {renderCountryFlagWithName({
-                  country: countryCode,
-                  name,
-                })}
-              </ListboxOption>
-            )
-          })}
-        </ListboxList>
-      </ListboxPopover>
-    </ListboxInput>
+              return (
+                <ListboxOption
+                  value={countryCode}
+                  label={name}
+                  key={countryCode}
+                >
+                  {renderCountryFlagWithName({
+                    country: countryCode,
+                    name,
+                  })}
+                </ListboxOption>
+              )
+            })}
+          </ListboxList>
+        </ListboxPopover>
+      </ListboxInput>
+    </>
   )
 }
 

--- a/react/LocationInput.tsx
+++ b/react/LocationInput.tsx
@@ -3,9 +3,13 @@ import { useAddressContext } from 'vtex.address-context/AddressContext'
 import { IconSearch, Input, Button, ButtonPlain } from 'vtex.styleguide'
 import { FormattedMessage, useIntl } from 'react-intl'
 import { useLazyQuery } from 'react-apollo'
-import { Address } from 'vtex.places-graphql'
 import { useRuntime } from 'vtex.render-runtime'
 import msk from 'msk'
+import {
+  Address,
+  Query,
+  QueryGetAddressFromPostalCodeArgs,
+} from 'vtex.places-graphql'
 
 import GET_ADDRESS_FROM_POSTAL_CODE from './graphql/getAddressFromPostalCode.graphql'
 import styles from './LocationInput.css'
@@ -23,9 +27,10 @@ const LocationInput: React.FC<Props> = ({
   const { culture } = useRuntime()
   const intl = useIntl()
   const [inputValue, setInputValue] = useState('')
-  const [executeGetAddressFromPostalCode, { error, data }] = useLazyQuery(
-    GET_ADDRESS_FROM_POSTAL_CODE
-  )
+  const [executeGetAddressFromPostalCode, { error, data }] = useLazyQuery<
+    Query,
+    QueryGetAddressFromPostalCodeArgs
+  >(GET_ADDRESS_FROM_POSTAL_CODE)
   const [loading, setLoading] = useState(false)
   const [invalidPostalCode, setInvalidPostalCode] = useState(false)
 
@@ -36,7 +41,7 @@ const LocationInput: React.FC<Props> = ({
   useEffect(() => {
     let cancelled = false
 
-    if (data) {
+    if (data?.getAddressFromPostalCode) {
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       ;(onSuccess?.(data.getAddressFromPostalCode) || Promise.resolve())
         .then(() => {

--- a/react/LocationSearch.tsx
+++ b/react/LocationSearch.tsx
@@ -92,7 +92,11 @@ const LocationSearch: React.FC<LocationSearchProps> = ({
   ] = useLazyQuery<Query, QuerySuggestAddressesArgs>(SUGGEST_ADDRESSES)
   const [
     executeGetAddressByExternalId,
-    { data: getAddressByExternalIdData, error: getAddressByExternalIdError },
+    {
+      data: getAddressByExternalIdData,
+      error: getAddressByExternalIdError,
+      loading: getAddressByExternalIdLoading,
+    },
   ] = useLazyQuery<Query, QueryGetAddressByExternalIdArgs>(
     GET_ADDRESS_BY_EXTERNAL_ID
   )
@@ -166,7 +170,9 @@ const LocationSearch: React.FC<LocationSearchProps> = ({
               </div>
             }
             suffix={
-              searchTerm.trim().length ? (
+              getAddressByExternalIdLoading ? (
+                <Spinner size={20} />
+              ) : searchTerm.trim().length ? (
                 <span
                   data-testid="location-search-clear"
                   role="button"
@@ -181,6 +187,7 @@ const LocationSearch: React.FC<LocationSearchProps> = ({
                 </span>
               ) : null
             }
+            disabled={getAddressByExternalIdLoading}
             value={searchTerm}
             onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
               setSearchTerm(event.target.value)

--- a/react/LocationSearch.tsx
+++ b/react/LocationSearch.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react'
+import React, { useState, useRef, useEffect, ReactNode } from 'react'
 import { FormattedMessage } from 'react-intl'
 import {
   Input,
@@ -64,11 +64,13 @@ const renderSuggestionText = ({
 }
 
 interface LocationSearchProps {
+  label?: ReactNode | string
   onSelectAddress?: (address: Address) => void
   renderEngineLogo?: () => React.ReactNode
 }
 
 const LocationSearch: React.FC<LocationSearchProps> = ({
+  label = <FormattedMessage id="place-components.label.autocompleteAddress" />,
   onSelectAddress,
   renderEngineLogo,
 }) => {
@@ -157,9 +159,7 @@ const LocationSearch: React.FC<LocationSearchProps> = ({
             as={Input}
             size="large"
             testId="location-search-input"
-            label={
-              <FormattedMessage id="place-components.label.autocompleteAddress" />
-            }
+            label={label}
             prefix={
               <div className="c-action-primary flex justify-center items-center">
                 <IconSearch />

--- a/react/LocationSearch.tsx
+++ b/react/LocationSearch.tsx
@@ -155,6 +155,7 @@ const LocationSearch: React.FC<LocationSearchProps> = ({
         <div ref={inputWrapperRef}>
           <ComboboxInput
             as={Input}
+            size="large"
             testId="location-search-input"
             label={
               <FormattedMessage id="place-components.label.autocompleteAddress" />

--- a/react/LocationSearch.tsx
+++ b/react/LocationSearch.tsx
@@ -188,7 +188,7 @@ const LocationSearch: React.FC<LocationSearchProps> = ({
             onKeyDown={handleKeyDown}
           />
         </div>
-        {searchTerm.trim().length ? (
+        {debouncedSearchTerm.trim().length ? (
           <ComboboxPopover
             position={(_targetRect, popoverRect) =>
               positionMatchWidth(

--- a/react/LocationSearch.tsx
+++ b/react/LocationSearch.tsx
@@ -91,11 +91,11 @@ const LocationSearch: React.FC<LocationSearchProps> = ({
     },
   ] = useLazyQuery<Query, QuerySuggestAddressesArgs>(SUGGEST_ADDRESSES)
   const [
-    executeGetAddressByExternalId,
+    executeGetAddress,
     {
-      data: getAddressByExternalIdData,
-      error: getAddressByExternalIdError,
-      loading: getAddressByExternalIdLoading,
+      data: getAddressData,
+      error: getAddressError,
+      loading: getAddressLoading,
     },
   ] = useLazyQuery<Query, QueryGetAddressByExternalIdArgs>(
     GET_ADDRESS_BY_EXTERNAL_ID
@@ -121,19 +121,17 @@ const LocationSearch: React.FC<LocationSearchProps> = ({
   }, [suggestAddressesData, suggestAddressesError, setSuggestions])
 
   useEffect(() => {
-    if (getAddressByExternalIdData) {
-      setAddress(getAddressByExternalIdData.getAddressByExternalId)
-      onSelectAddress?.(getAddressByExternalIdData.getAddressByExternalId)
+    if (getAddressData) {
+      setAddress(prevAddress => ({
+        ...prevAddress,
+        ...getAddressData.getAddressByExternalId,
+      }))
+      onSelectAddress?.(getAddressData.getAddressByExternalId)
     }
-    if (getAddressByExternalIdError) {
-      console.error(getAddressByExternalIdError.message)
+    if (getAddressError) {
+      console.error(getAddressError.message)
     }
-  }, [
-    getAddressByExternalIdData,
-    getAddressByExternalIdError,
-    onSelectAddress,
-    setAddress,
-  ])
+  }, [getAddressData, getAddressError, onSelectAddress, setAddress])
 
   const handleKeyDown = (event: React.KeyboardEvent) => {
     if (event.key !== 'Escape') {
@@ -147,12 +145,13 @@ const LocationSearch: React.FC<LocationSearchProps> = ({
       address => address.description === selectedAddress
     )?.externalId
 
-    if (id) {
-      setSearchTerm(selectedAddress)
-      executeGetAddressByExternalId({ variables: { id } })
-    } else {
+    if (id == null) {
       console.error(`${selectedAddress} was not found`)
+      return
     }
+
+    setSearchTerm(selectedAddress)
+    executeGetAddress({ variables: { id } })
   }
 
   return (
@@ -170,7 +169,7 @@ const LocationSearch: React.FC<LocationSearchProps> = ({
               </div>
             }
             suffix={
-              getAddressByExternalIdLoading ? (
+              getAddressLoading ? (
                 <Spinner size={20} />
               ) : searchTerm.trim().length ? (
                 <span
@@ -187,7 +186,7 @@ const LocationSearch: React.FC<LocationSearchProps> = ({
                 </span>
               ) : null
             }
-            disabled={getAddressByExternalIdLoading}
+            disabled={getAddressLoading}
             value={searchTerm}
             onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
               setSearchTerm(event.target.value)


### PR DESCRIPTION
#### What problem is this solving?

Label wasn't showing up in LocationCountry component.

#### How should this be manually tested?

- [Workspace](https://w0geo--checkoutio.myvtex.com/cart/add?sku=289)
- Go to shipping step
- Compare to [Figma](https://www.figma.com/file/umwHrHA8nifvQIPEN3DHpX/Checkout-IO---Library?node-id=97%3A15)

#### Screenshots or example usage

|Figma|Proposal|
|-|-|
| ![image](https://user-images.githubusercontent.com/26108090/98712514-2ab36100-2365-11eb-973c-1008114360c6.png) | ![image](https://user-images.githubusercontent.com/26108090/98712477-1ff8cc00-2365-11eb-9371-8fc61d3a19da.png) |


#### Notes

The LocationCountry component will appear on a 50% chance _for this workspace only_. The reason for that is because the condition for LocationCountry appear is to have multiple countries defined by the sales channels. There is no easy way to simulate that on IO yet, and making two separate workspaces isn't possible due to a very recent store framework (?) bug. So please, refresh the page until it works :worry-sparkle: