### PR TITLE
Fix undefined message id for postal code field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `undefined` message id for postal code field.
 
 ## [0.13.1] - 2020-11-19
 ### Fixed

--- a/react/AddressForm.tsx
+++ b/react/AddressForm.tsx
@@ -55,6 +55,10 @@ const messages = defineMessages({
     defaultMessage: '',
     id: 'place-components.error.fieldRequired',
   },
+  postalCode: {
+    defaultMessage: '',
+    id: 'place-components.label.postalCode',
+  },
 })
 
 /**


### PR DESCRIPTION
#### What problem is this solving?

This PR fixes a problem which was preventing the user from selecting a pickup option. This was happening because the `formatMessage` function was receiving an undefined value for postal code field.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

- [Add item to cart](https://unifyshipping--checkoutio.myvtex.com/cart/add?sku=307)
- Insert a postal code `22230001` (but without selecting a shipping option)
- Proceed to checkout
- Select a pickup option
- It shouldn't throw an error

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/12574426/100884343-1fe57b00-3490-11eb-83d3-88747aba3fb4.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
