### PR TITLE
Add id to elements used to calculate shipping through e2e tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `id` to the input and button used to insert postal code through e2e tests.
 
 ## [0.13.4] - 2020-12-09
 ### Added

--- a/react/LocationInput.tsx
+++ b/react/LocationInput.tsx
@@ -113,9 +113,11 @@ const LocationInput: React.FC<Props> = ({
     <div className="w-100">
       <form className={`${styles.locationInput} mb4`} onSubmit={handleSubmit}>
         <Input
+          id="postal-code-input"
           label={<FormattedMessage id="place-components.label.postalCode" />}
           suffix={
             <Button
+              id="submit-postal-code"
               type="submit"
               onClick={handleSubmit}
               isLoading={loading}

--- a/react/LocationInput.tsx
+++ b/react/LocationInput.tsx
@@ -117,7 +117,7 @@ const LocationInput: React.FC<Props> = ({
           label={<FormattedMessage id="place-components.label.postalCode" />}
           suffix={
             <Button
-              id="submit-postal-code"
+              id="submit-postal-code-button"
               type="submit"
               onClick={handleSubmit}
               isLoading={loading}


### PR DESCRIPTION
#### What problem is this solving?

This PR adds ids to the elements, in order to calculate shipping through the e2e tests.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://pickupe2e--checkoutio.myvtex.com/cart/add?sku=307)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
