### PR TITLE
CHK-469: Address suggestions restricted by country

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `LocationSearch` results can now be restricted per country.
 
 ## [0.13.6] - 2020-12-16
 ### Added

--- a/react/LocationCountry.tsx
+++ b/react/LocationCountry.tsx
@@ -116,7 +116,6 @@ const LocationCountry: React.FC<LocationCountryProps> = ({
       <ListboxInput
         translate={undefined}
         aria-labelledby={labelId}
-        className="h-100"
         value={country}
         onChange={setCountry}
       >

--- a/react/LocationSearch.tsx
+++ b/react/LocationSearch.tsx
@@ -165,17 +165,17 @@ const LocationSearch: React.FC<LocationSearchProps> = ({
     setDisplayedSearchTerm('')
   }
 
-  const handleAddressSelection = (selectedAddress: string) => {
+  const handleSuggestionSelection = (selectedSuggestion: string) => {
     const externalId = suggestions.find(
-      address => address.description === selectedAddress
+      suggestion => suggestion.description === selectedSuggestion
     )?.externalId
 
     if (externalId == null) {
-      console.error(`${selectedAddress} was not found`)
+      console.error(`${selectedSuggestion} was not found`)
       return
     }
 
-    setDisplayedSearchTerm(selectedAddress)
+    setDisplayedSearchTerm(selectedSuggestion)
     executeAddress({ variables: { externalId, sessionToken } })
     refetchSessionToken()
   }
@@ -192,7 +192,7 @@ const LocationSearch: React.FC<LocationSearchProps> = ({
 
   return (
     <div className="w-100">
-      <Combobox onSelect={handleAddressSelection}>
+      <Combobox onSelect={handleSuggestionSelection}>
         <div ref={inputWrapperRef}>
           <ComboboxInput
             as={Input}
@@ -239,10 +239,10 @@ const LocationSearch: React.FC<LocationSearchProps> = ({
           >
             {suggestions.length > 0 ? (
               <ComboboxList>
-                {suggestions.map((address, index) => (
-                  <ComboboxOption value={address.description} key={index}>
+                {suggestions.map((suggestion, index) => (
+                  <ComboboxOption value={suggestion.description} key={index}>
                     <PlaceIcon className="flex flex-shrink-0 mr4 c-muted-1" />
-                    {renderSuggestionText(address)}
+                    {renderSuggestionText(suggestion)}
                   </ComboboxOption>
                 ))}
               </ComboboxList>

--- a/react/LocationSearch.tsx
+++ b/react/LocationSearch.tsx
@@ -59,7 +59,8 @@ const useDebouncedValue = (value: string, delayInMs: number): string => {
 
 const useSuggestions = (
   searchTerm: string,
-  sessionToken: string | null
+  sessionToken?: string | null,
+  country?: string | null
 ): [AddressSuggestion[], boolean] => {
   const [executeAddressSuggestions, { data, error, loading }] = useLazyQuery<
     Query,
@@ -68,11 +69,13 @@ const useSuggestions = (
 
   useEffect(() => {
     if (searchTerm.trim().length) {
-      executeAddressSuggestions({ variables: { searchTerm, sessionToken } })
+      executeAddressSuggestions({
+        variables: { searchTerm, sessionToken, country },
+      })
     }
     // the effect shouldn't be triggered when the sessionToken changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchTerm, executeAddressSuggestions])
+  }, [searchTerm, country, executeAddressSuggestions])
 
   useEffect(() => {
     if (error) {
@@ -112,7 +115,7 @@ const LocationSearch: React.FC<LocationSearchProps> = ({
   const [searchTerm, setSearchTerm] = useState('')
   const [displayedSearchTerm, setDisplayedSearchTerm] = useState('')
   const inputWrapperRef = useRef<HTMLDivElement>(null)
-  const { setAddress } = useAddressContext()
+  const { address, setAddress } = useAddressContext()
   const providerLogo = useProviderLogo()
   const debouncedSearchTerm = useDebouncedValue(
     searchTerm,
@@ -126,7 +129,8 @@ const LocationSearch: React.FC<LocationSearchProps> = ({
   const sessionToken = sessionTokenData?.sessionToken ?? null
   const [suggestions, loadingSuggestions] = useSuggestions(
     debouncedSearchTerm,
-    sessionToken
+    sessionToken,
+    address?.country
   )
 
   const [executeAddress, { data, error, loading }] = useLazyQuery<

--- a/react/graphql/addressSuggestions.graphql
+++ b/react/graphql/addressSuggestions.graphql
@@ -1,6 +1,13 @@
-query AddressSuggestions($searchTerm: String!, $sessionToken: String) {
-  addressSuggestions(searchTerm: $searchTerm, sessionToken: $sessionToken)
-    @context(provider: "vtex.geolocation-graphql-interface") {
+query AddressSuggestions(
+  $searchTerm: String!
+  $sessionToken: String
+  $country: String
+) {
+  addressSuggestions(
+    searchTerm: $searchTerm
+    sessionToken: $sessionToken
+    country: $country
+  ) @context(provider: "vtex.geolocation-graphql-interface") {
     description
     mainText
     mainTextMatchInterval {

--- a/react/package.json
+++ b/react/package.json
@@ -26,12 +26,12 @@
     "apollo-client": "^2.6.10",
     "vtex.address-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.address-context@0.5.0/public/@types/vtex.address-context",
     "vtex.checkout-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-components@0.5.1/public/@types/vtex.checkout-components",
-    "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.52.1/public/@types/vtex.checkout-graphql",
+    "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.55.1/public/@types/vtex.checkout-graphql",
     "vtex.country-flags": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.country-flags@0.1.1/public/@types/vtex.country-flags",
-    "vtex.geolocation-graphql-interface": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.geolocation-graphql-interface@0.2.0/public/@types/vtex.geolocation-graphql-interface",
+    "vtex.geolocation-graphql-interface": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.geolocation-graphql-interface@0.3.0/public/@types/vtex.geolocation-graphql-interface",
     "vtex.places-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.places-graphql@0.4.0/public/@types/vtex.places-graphql",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.4/public/@types/vtex.render-runtime",
-    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.134.0/public/@types/vtex.styleguide"
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.5/public/@types/vtex.render-runtime",
+    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.134.1/public/@types/vtex.styleguide"
   },
   "version": "0.13.6"
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -6288,29 +6288,29 @@ vtex-tachyons@^3.2.0:
   version "0.5.1"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-components@0.5.1/public/@types/vtex.checkout-components#77d654aea75319f3024612fe7b263777b116105f"
 
-"vtex.checkout-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.52.1/public/@types/vtex.checkout-graphql":
-  version "0.52.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.52.1/public/@types/vtex.checkout-graphql#226ec5cc59c71065410ce9414c031ce942511701"
+"vtex.checkout-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.55.1/public/@types/vtex.checkout-graphql":
+  version "0.55.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.55.1/public/@types/vtex.checkout-graphql#a9f282941d74fffac3d3d877d92313dd755de07f"
 
 "vtex.country-flags@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.country-flags@0.1.1/public/@types/vtex.country-flags":
   version "0.1.1"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.country-flags@0.1.1/public/@types/vtex.country-flags#90f42d100c364aa8b549bd8b8c88c8dc9550686a"
 
-"vtex.geolocation-graphql-interface@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.geolocation-graphql-interface@0.2.0/public/@types/vtex.geolocation-graphql-interface":
-  version "0.2.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.geolocation-graphql-interface@0.2.0/public/@types/vtex.geolocation-graphql-interface#eee30f5c90617f351b132bd6447f7c88150cba94"
+"vtex.geolocation-graphql-interface@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.geolocation-graphql-interface@0.3.0/public/@types/vtex.geolocation-graphql-interface":
+  version "0.3.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.geolocation-graphql-interface@0.3.0/public/@types/vtex.geolocation-graphql-interface#7d8c16d1c0e71d7337afcbabaf4c0a2811d60a3b"
 
 "vtex.places-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.places-graphql@0.4.0/public/@types/vtex.places-graphql":
   version "0.4.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.places-graphql@0.4.0/public/@types/vtex.places-graphql#19d8522f344c82c677b474829deb629583def399"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.4/public/@types/vtex.render-runtime":
-  version "8.126.4"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.4/public/@types/vtex.render-runtime#40d7ad8a7b04c50e61ff84a1089dcf7045efd548"
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.5/public/@types/vtex.render-runtime":
+  version "8.126.5"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.5/public/@types/vtex.render-runtime#f529e960313579c39a9748820885b995f9d6d3e6"
 
-"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.134.0/public/@types/vtex.styleguide":
-  version "9.134.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.134.0/public/@types/vtex.styleguide#9ce9062c2a0f9925d7a926a9c4d544b4f0409590"
+"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.134.1/public/@types/vtex.styleguide":
+  version "9.134.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.134.1/public/@types/vtex.styleguide#7210ed4908f4e6482d2499d71c4cfcc21e3dfd6a"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
#### What problem is this solving?

LocationSearch passes country from address context to addressSuggestions query, restricting the results to the specified country. Depends on https://github.com/vtex-apps/geolocation-graphql-interface/pull/7

#### How should this be manually tested?

- [Add global product to cart](https://geolocation--checkoutio.myvtex.com/cart/add?sku=312)
- Choose delivery options
- Check how suggestions change based on the country you choose

Obs: it's safe to test with Brazil and USA, other countries might crash.

#### Screenshots or example usage

on Brazil | on USA
-|-
![image](https://user-images.githubusercontent.com/26108090/103226125-2a1d5c80-490a-11eb-955e-6dea18d08417.png) | ![image](https://user-images.githubusercontent.com/26108090/103226160-3ef9f000-490a-11eb-8645-83dba6637744.png)

#### Notes

I don't think there are any relevant tests to add.