### PR TITLE
CHK-488: Fix geolocation on Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Geolocation on Safari.
 
 ## [0.13.8] - 2020-12-30
 ### Fixed

--- a/react/DeviceCoordinates.tsx
+++ b/react/DeviceCoordinates.tsx
@@ -84,6 +84,11 @@ const DeviceCoordinates: React.FC<Props> = ({ onSuccess }) => {
   }
 
   useEffect(() => {
+    // some browsers do not have/require permissions
+    if (!navigator.permissions) {
+      return
+    }
+
     navigator.permissions
       .query({ name: 'geolocation' })
       .then((result: PermissionStatus) => {

--- a/react/__fixtures__/address.fixture.tsx
+++ b/react/__fixtures__/address.fixture.tsx
@@ -63,3 +63,19 @@ export const sampleAddress: Address = {
   receiverName: null,
   reference: null,
 }
+
+export const vtexOfficeAddress = {
+  addressId: '1',
+  addressType: 'residential',
+  city: 'Rio de Janeiro',
+  complement: null,
+  country: 'BRA',
+  geoCoordinates: [-43.18037200000001, -22.9418474],
+  neighborhood: 'Botafogo',
+  number: '200',
+  postalCode: '22250-145',
+  receiverName: null,
+  reference: null,
+  state: 'RJ',
+  street: 'Rua Praia de Botafogo',
+}

--- a/react/__fixtures__/graphql/address.fixture.tsx
+++ b/react/__fixtures__/graphql/address.fixture.tsx
@@ -3,6 +3,7 @@ import { MockedResponse } from '@apollo/react-testing'
 
 import ADDRESS from '../../graphql/address.graphql'
 import { DEFAULT_SESSION_TOKEN } from './sessionToken.fixture'
+import { vtexOfficeAddress } from '../address.fixture'
 
 export const simpleSuggestedAddress: MockedResponse = {
   request: {
@@ -14,24 +15,7 @@ export const simpleSuggestedAddress: MockedResponse = {
   },
   result: {
     data: {
-      address: {
-        addressId: '1',
-        addressType: 'residential',
-        city: 'Rio de Janeiro',
-        complement: null,
-        country: 'BRA',
-        geoCoordinates: [
-          -43.18037200000001,
-          -22.9418474,
-        ] as Query['address']['geoCoordinates'],
-        neighborhood: 'Botafogo',
-        number: '200',
-        postalCode: '22250-145',
-        receiverName: null,
-        reference: null,
-        state: 'RJ',
-        street: 'Rua Praia de Botafogo',
-      } as Query['address'],
+      address: vtexOfficeAddress,
     } as Query,
   },
 }

--- a/react/__fixtures__/graphql/reverseGeocode.fixture.tsx
+++ b/react/__fixtures__/graphql/reverseGeocode.fixture.tsx
@@ -1,0 +1,24 @@
+import { MockedResponse } from '@apollo/react-testing'
+import { Query, QueryReverseGeocodeArgs } from 'vtex.places-graphql'
+
+import { vtexOfficeAddress } from '../address.fixture'
+import REVERSE_GEOCODE_QUERY from '../../graphql/reverseGeocode.graphql'
+
+const [lat, lng] = vtexOfficeAddress.geoCoordinates.map(coordinate =>
+  coordinate.toString()
+)
+
+export const reverseGeocode: MockedResponse = {
+  request: {
+    query: REVERSE_GEOCODE_QUERY,
+    variables: {
+      lat,
+      lng,
+    } as QueryReverseGeocodeArgs,
+  },
+  result: {
+    data: {
+      reverseGeocode: vtexOfficeAddress,
+    } as Query,
+  },
+}

--- a/react/__mocks__/vtex.styleguide.tsx
+++ b/react/__mocks__/vtex.styleguide.tsx
@@ -15,3 +15,5 @@ export { default as IconSearch } from '@vtex/styleguide/lib/icon/Search'
 export { default as IconClear } from '@vtex/styleguide/lib/icon/Clear'
 // @ts-ignore
 export { default as IconWarning } from '@vtex/styleguide/lib/icon/Warning'
+// @ts-ignore
+export { default as IconLocation } from '@vtex/styleguide/lib/icon/Location'

--- a/react/__tests__/DeviceCoordinates.test.tsx
+++ b/react/__tests__/DeviceCoordinates.test.tsx
@@ -1,0 +1,164 @@
+import React from 'react'
+import { fireEvent, render, screen, waitFor } from '@vtex/test-tools/react'
+import { MockedProvider, MockedResponse } from '@apollo/react-testing'
+import { Address } from 'vtex.checkout-graphql'
+import { AddressRules } from 'vtex.address-context/types'
+
+import { AddressContextProvider } from '../__mocks__/vtex.address-context/AddressContext'
+import DeviceCoordinates from '../DeviceCoordinates'
+import { reverseGeocode } from '../__fixtures__/graphql/reverseGeocode.fixture'
+import { vtexOfficeAddress } from '../__fixtures__/address.fixture'
+
+interface RenderComponentProps {
+  deviceCoordinatesProps?: React.ComponentProps<typeof DeviceCoordinates>
+  address?: Address | null
+  countries?: string[]
+  rules?: AddressRules
+  graphqlMocks?: MockedResponse[]
+}
+
+const defaultGraphqlMocks = [] as MockedResponse[]
+
+describe('Device Coordinates', () => {
+  const renderComponent = ({
+    deviceCoordinatesProps,
+    address = { country: 'BRA' },
+    countries = [],
+    rules = {},
+    graphqlMocks = [],
+  }: RenderComponentProps) => {
+    return render(
+      <MockedProvider
+        addTypename={false}
+        mocks={[...defaultGraphqlMocks, ...graphqlMocks]}
+      >
+        <AddressContextProvider
+          address={address}
+          countries={countries}
+          rules={rules}
+        >
+          <DeviceCoordinates {...deviceCoordinatesProps} />
+        </AddressContextProvider>
+      </MockedProvider>
+    )
+  }
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('when geolocation is granted', () => {
+    it('should get an address from coordinates', async () => {
+      const callOrder: string[] = []
+
+      const { query } = navigator.permissions
+      const mockedPermissionsQuery = query as jest.MockedFunction<typeof query>
+
+      mockedPermissionsQuery.mockImplementation(_permission => {
+        callOrder.push('permissions')
+
+        return Promise.resolve({ state: 'granted' } as PermissionStatus)
+      })
+
+      Object.defineProperty(navigator, 'permissions', {
+        get() {
+          return { query: mockedPermissionsQuery }
+        },
+      })
+
+      const { getCurrentPosition } = navigator.geolocation
+      const mockedGetCurrentPosition = getCurrentPosition as jest.MockedFunction<
+        typeof getCurrentPosition
+      >
+
+      mockedGetCurrentPosition.mockImplementation(success => {
+        callOrder.push('geolocation')
+
+        return Promise.resolve(
+          success({
+            coords: {
+              latitude: vtexOfficeAddress.geoCoordinates[0],
+              longitude: vtexOfficeAddress.geoCoordinates[1],
+            },
+          } as GeolocationPosition)
+        )
+      })
+
+      Object.defineProperty(navigator, 'geolocation', {
+        get() {
+          return { getCurrentPosition: mockedGetCurrentPosition }
+        },
+      })
+
+      const mockedOnSuccess = jest.fn()
+
+      renderComponent({
+        deviceCoordinatesProps: { onSuccess: mockedOnSuccess },
+        graphqlMocks: [reverseGeocode],
+      })
+
+      const button = screen.getByRole('button')
+
+      fireEvent.click(button)
+
+      expect(mockedPermissionsQuery).toHaveBeenCalledTimes(1)
+      expect(mockedGetCurrentPosition).toHaveBeenCalledTimes(1)
+      expect(callOrder).toEqual(['permissions', 'geolocation'])
+      await waitFor(() => {
+        expect(mockedOnSuccess).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    it("should get an address from coordinates on a browser that doesn't support navigator.permissions", async () => {
+      Object.defineProperty(navigator, 'permissions', {
+        get() {
+          return undefined
+        },
+      })
+
+      const { getCurrentPosition } = navigator.geolocation
+      const mockedGetCurrentPosition = getCurrentPosition as jest.MockedFunction<
+        typeof getCurrentPosition
+      >
+
+      mockedGetCurrentPosition.mockImplementation(success =>
+        Promise.resolve(
+          success({
+            coords: {
+              latitude: vtexOfficeAddress.geoCoordinates[0],
+              longitude: vtexOfficeAddress.geoCoordinates[1],
+            },
+          } as GeolocationPosition)
+        )
+      )
+
+      Object.defineProperty(navigator, 'geolocation', {
+        get() {
+          return { getCurrentPosition: mockedGetCurrentPosition }
+        },
+      })
+
+      const mockedOnSuccess = jest.fn()
+
+      renderComponent({
+        deviceCoordinatesProps: { onSuccess: mockedOnSuccess },
+        graphqlMocks: [reverseGeocode],
+      })
+
+      const button = screen.getByRole('button')
+
+      fireEvent.click(button)
+
+      expect(mockedGetCurrentPosition).toHaveBeenCalledTimes(1)
+      await waitFor(() => {
+        expect(mockedOnSuccess).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
+
+  // TODO
+  describe('when geolocation is blocked', () => {})
+
+  // TODO
+  describe('when geolocation is prompt', () => {})
+})

--- a/react/package.json
+++ b/react/package.json
@@ -33,5 +33,10 @@
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.5/public/@types/vtex.render-runtime",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.134.1/public/@types/vtex.styleguide"
   },
+  "jest": {
+    "setupFilesAfterEnv": [
+      "<rootDir>/setupTests.js"
+    ]
+  },
   "version": "0.13.8"
 }

--- a/react/setupTests.js
+++ b/react/setupTests.js
@@ -1,0 +1,7 @@
+global.navigator.geolocation = {
+  getCurrentPosition: jest.fn(),
+}
+
+global.navigator.permissions = {
+  query: jest.fn(),
+}

--- a/react/tsconfig.json
+++ b/react/tsconfig.json
@@ -3,11 +3,7 @@
     "alwaysStrict": true,
     "esModuleInterop": true,
     "jsx": "react",
-    "lib": [
-      "es2017",
-      "dom",
-      "es2018.promise"
-    ],
+    "lib": ["es2017", "dom", "es2018.promise"],
     "module": "esnext",
     "moduleResolution": "node",
     "noImplicitAny": true,
@@ -20,9 +16,5 @@
     "strictPropertyInitialization": true,
     "target": "es2017"
   },
-  "include": [
-    "./typings/*.d.ts",
-    "./**/*.tsx",
-    "./**/*.ts"
-  ]
+  "include": ["./typings/*.d.ts", "./**/*.tsx", "./**/*.ts", "setupTests.js"]
 }


### PR DESCRIPTION
#### What problem is this solving?

Shipping breaks on safari due to a bug in device coordinate component.

![image](https://user-images.githubusercontent.com/26108090/103381932-07d33c80-4acc-11eb-9818-4ed2e3b8e9bf.png)

Turns out that the problem is because some browsers don't support asking for `permission`. See more about that [here](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/permissions#Browser_compatibility).

#### How should this be manually tested?

- open safari on pc
- [workspace](https://geolocation--checkoutio.myvtex.com/cart/add?sku=312)
- click on delivery options and click on device coordinate

It should prompt for your geolocation and work normally.

#### Notes

Should we create a unit test for this? I feel like an e2e test for safari with complete purchase flow would be enough, but idk.
