### PR TITLE
CHK-470: Add typing for `brief` display field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Typing for `brief` display field.
 
 ## [0.13.9] - 2021-01-08
 ### Fixed

--- a/react/typings/countryRulesTypes.d.ts
+++ b/react/typings/countryRulesTypes.d.ts
@@ -21,6 +21,7 @@ export interface Field {
 
 export interface Display {
   minimal: LineFragment[][]
+  brief: LineFragment[][]
   compact: LineFragment[][]
   extended: LineFragment[][]
 }


### PR DESCRIPTION
#### What problem is this solving?

Adds typing for new field on https://github.com/vtex-apps/country-data-settings/pull/5.

Depends on https://github.com/vtex-apps/address-context/pull/10.

#### How should this be manually tested?

NA