### PR TITLE
Fix whitespace in delimiters truncated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Whitespace truncated in address fields delimiters.
 
 ## [0.13.9] - 2021-01-08
 ### Fixed

--- a/react/PlaceDetails.tsx
+++ b/react/PlaceDetails.tsx
@@ -69,11 +69,15 @@ const PlaceDetails: React.FC<Props> = ({
               return (
                 <div className="dib" key={fragment.name}>
                   {fragment.delimiter && hasPreviousFragment && (
-                    <span>{fragment.delimiter}</span>
+                    <span style={{ whiteSpace: 'pre-wrap' }}>
+                      {fragment.delimiter}
+                    </span>
                   )}
                   <span className={fragment.name}>{addressValue}</span>
                   {fragment.delimiterAfter && shouldShowDelimiter && (
-                    <span>{fragment.delimiterAfter}</span>
+                    <span style={{ whiteSpace: 'pre-wrap' }}>
+                      {fragment.delimiterAfter}
+                    </span>
                   )}
                 </div>
               )


### PR DESCRIPTION
#### What problem is this solving?

The whitespace in the field's delimiters were being truncated because HTML automatically ignores whitespaces in the beggining or end of tags

#### How should this be manually tested?

[Workspace](https://lucas--checkoutio.myvtex.com/cart/add?sku=312&sc=2).

Keep in mind that in this workspace I also have other stuff linked, so if anything breaks it may be other repo's fault 👀

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

Before

![image](https://user-images.githubusercontent.com/10223856/106182539-bdea7e80-617d-11eb-8ffb-443a437fcc21.png)

After

![image](https://user-images.githubusercontent.com/10223856/106182417-87146880-617d-11eb-9be0-78032ab0599b.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->