### PR TITLE
Fix empty fields hidden in address form component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Empty fields being hidden inside address form.
 
 ## [0.13.10] - 2021-02-01
 ### Fixed

--- a/react/AddressForm.tsx
+++ b/react/AddressForm.tsx
@@ -190,8 +190,7 @@ const AddressForm: React.FC<AddressFormProps> = ({
               if (
                 !field ||
                 ignoredFields.has(fragment.name) ||
-                hiddenFields.includes(fragment.name) ||
-                address[fragment.name] == null
+                hiddenFields.includes(fragment.name)
               ) {
                 return false
               }
@@ -219,7 +218,7 @@ const AddressForm: React.FC<AddressFormProps> = ({
                   }))
                 }
 
-                const value = address[fragment.name] as string
+                const value = address[fragment.name] ?? ''
 
                 const commonProps = {
                   label: intl.formatMessage(


### PR DESCRIPTION
#### What problem is this solving?

Fixes an issue where empty fields with `null` were being hidden instead of shown as an empty input.

#### How should this be manually tested?

[Workspace](https://addr--checkoutio.myvtex.com/cart/add?sku=289).

You can see that in the address step of checkout the complement will always be shown.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
