### PR TITLE
CHK-550: Properly handle error state on LocationInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `LocationInput` error state is handled properly.
 
 ## [0.14.0] - 2021-02-12
 ### Added

--- a/react/__fixtures__/address.fixture.tsx
+++ b/react/__fixtures__/address.fixture.tsx
@@ -64,7 +64,7 @@ export const sampleAddress: Address = {
   reference: null,
 }
 
-export const vtexOfficeAddress = {
+export const vtexOfficeAddress: Address = {
   addressId: '1',
   addressType: 'residential',
   city: 'Rio de Janeiro',

--- a/react/__fixtures__/graphql/addressSuggestions.fixture.tsx
+++ b/react/__fixtures__/graphql/addressSuggestions.fixture.tsx
@@ -13,6 +13,7 @@ export const simpleSuggestions: MockedResponse = {
     variables: {
       searchTerm: 'Praia de Botafogo',
       sessionToken: DEFAULT_SESSION_TOKEN,
+      country: 'BRA',
     } as QueryAddressSuggestionsArgs,
   },
   result: {
@@ -60,6 +61,7 @@ export const noSuggestions: MockedResponse = {
     variables: {
       searchTerm: 'asdfasdfasdf',
       sessionToken: DEFAULT_SESSION_TOKEN,
+      country: 'BRA',
     } as QueryAddressSuggestionsArgs,
   },
   result: {

--- a/react/__fixtures__/graphql/getAddressFromPostalCode.fixture.ts
+++ b/react/__fixtures__/graphql/getAddressFromPostalCode.fixture.ts
@@ -1,0 +1,33 @@
+import { Query, QueryGetAddressFromPostalCodeArgs } from 'vtex.places-graphql'
+import { MockedResponse } from '@apollo/react-testing'
+
+import GET_ADDRESS_FROM_POSTAL_CODE from '../../graphql/getAddressFromPostalCode.graphql'
+
+export const validPostalCode: MockedResponse = {
+  request: {
+    query: GET_ADDRESS_FROM_POSTAL_CODE,
+    variables: {
+      countryCode: 'BRA',
+      postalCode: '22250-040',
+    } as QueryGetAddressFromPostalCodeArgs,
+  },
+  result: {
+    data: {
+      getAddressFromPostalCode: {
+        addressId: null,
+        addressType: null,
+        city: 'Rio de Janeiro',
+        complement: '',
+        country: 'BRA',
+        geoCoordinates: [-43.18218231201172, -22.94549560546875],
+        neighborhood: 'Botafogo',
+        number: '',
+        postalCode: '22250040',
+        receiverName: null,
+        reference: '',
+        state: 'RJ',
+        street: 'Praia Botafogo',
+      },
+    } as Query,
+  },
+}

--- a/react/__mocks__/vtex.styleguide.tsx
+++ b/react/__mocks__/vtex.styleguide.tsx
@@ -17,3 +17,5 @@ export { default as IconClear } from '@vtex/styleguide/lib/icon/Clear'
 export { default as IconWarning } from '@vtex/styleguide/lib/icon/Warning'
 // @ts-ignore
 export { default as IconLocation } from '@vtex/styleguide/lib/icon/Location'
+// @ts-ignore
+export { default as Button } from '@vtex/styleguide/lib/Button'

--- a/react/__tests__/LocationInput.test.tsx
+++ b/react/__tests__/LocationInput.test.tsx
@@ -1,0 +1,136 @@
+import React from 'react'
+import { render, screen, waitFor } from '@vtex/test-tools/react'
+import { MockedResponse } from '@apollo/react-testing'
+import { Address } from 'vtex.checkout-graphql'
+import { AddressRules, CountryRules, Field } from 'vtex.address-context/types'
+import { AddressContextProvider } from 'vtex.address-context/AddressContext'
+import userEvent from '@testing-library/user-event'
+
+import LocationInput from '../LocationInput'
+import { validPostalCode } from '../__fixtures__/graphql/getAddressFromPostalCode.fixture'
+
+interface SetupProps {
+  address?: Address | null
+  countries?: string[]
+  rules?: AddressRules
+  graphqlMocks?: MockedResponse[]
+}
+
+interface RenderComponentProps extends SetupProps {
+  locationInputProps?: React.ComponentProps<typeof LocationInput>
+}
+
+const defaultGraphqlMocks: MockedResponse[] = []
+
+describe('LocationInput', () => {
+  const renderComponent = ({
+    locationInputProps = {},
+    address = { country: 'BRA' },
+    countries = [],
+    rules = {
+      BRA: {
+        fields: {
+          postalCode: {
+            mask: '99999-999',
+            pattern: '^(\\d){5}-?(\\d){3}$',
+            additionalData: {
+              forgottenURL:
+                'https://buscacepinter.correios.com.br/app/endereco/',
+            },
+          } as Field,
+        },
+      } as CountryRules,
+    },
+    graphqlMocks = [],
+  }: RenderComponentProps) => {
+    return render(
+      <AddressContextProvider
+        address={address}
+        countries={countries}
+        rules={rules}
+      >
+        <LocationInput {...locationInputProps} />
+      </AddressContextProvider>,
+      {
+        graphql: {
+          mocks: [...defaultGraphqlMocks, ...graphqlMocks],
+          addTypename: false,
+        },
+      }
+    )
+  }
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should format and submit a valid postal code', async () => {
+    const mockedOnSuccess = jest.fn()
+
+    renderComponent({
+      locationInputProps: { onSuccess: mockedOnSuccess },
+      graphqlMocks: [validPostalCode],
+    })
+
+    const input = screen.getByRole('textbox', {
+      name: /postal code/i,
+    })
+
+    userEvent.type(input, '22250040')
+    userEvent.click(screen.getByRole('button'))
+
+    await waitFor(() => {
+      expect(mockedOnSuccess).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('should format and submit a valid postal code after fixing an invalid postal code', async () => {
+    const mockedOnSuccess = jest.fn()
+
+    renderComponent({
+      locationInputProps: { onSuccess: mockedOnSuccess },
+      graphqlMocks: [validPostalCode],
+    })
+
+    const input = screen.getByRole('textbox', {
+      name: /postal code/i,
+    })
+
+    // it's missing the last digit
+    userEvent.type(input, '2225004')
+    userEvent.click(screen.getByRole('button'))
+
+    expect(
+      screen.getByText(/inform a valid postal code\./i)
+    ).toBeInTheDocument()
+
+    userEvent.type(input, '{selectall}22250040')
+    userEvent.click(screen.getByRole('button'))
+
+    await waitFor(() => {
+      expect(mockedOnSuccess).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('should apply the postal code mask when the input lose focus', () => {
+    renderComponent({})
+    const input = screen.getByRole('textbox', {
+      name: /postal code/i,
+    })
+
+    userEvent.type(input, '222500')
+    expect(input).toHaveValue('222500')
+
+    userEvent.type(input, '4')
+    expect(input).toHaveValue('2225004')
+
+    userEvent.click(screen.getByRole('button'))
+    expect(input).toHaveValue('22250-04')
+
+    userEvent.type(input, '{selectall}2225004')
+    expect(input).toHaveValue('2225004')
+
+    userEvent.type(input, '{enter}')
+    expect(input).toHaveValue('22250-04')
+  })
+})

--- a/react/__tests__/LocationSearch.test.tsx
+++ b/react/__tests__/LocationSearch.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen, fireEvent, act } from '@vtex/test-tools/react'
+import { render, screen, fireEvent, waitFor } from '@vtex/test-tools/react'
 import { MockedResponse } from '@apollo/react-testing'
 import { Address } from 'vtex.checkout-graphql'
 import { AddressRules } from 'vtex.address-context/types'
@@ -38,7 +38,7 @@ const defaultGraphqlMocks = [
 
 describe('Location Search', () => {
   const renderComponent = ({
-    address = null,
+    address = { country: 'BRA' },
     countries = [],
     rules = {},
     graphqlMocks = [],
@@ -86,10 +86,11 @@ describe('Location Search', () => {
     )
 
     // same as waiting loading to finish
-    expect(screen.queryByRole('button')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.queryByRole('button')).toBeInTheDocument()
+    })
   })
 
-  // TODO: fix act warning
   it('should be able to clear the input with clear button when something is typed', () => {
     renderComponent({ graphqlMocks: [simpleSuggestions] })
 
@@ -108,7 +109,6 @@ describe('Location Search', () => {
     expect(screen.queryByRole('button')).not.toBeInTheDocument()
   })
 
-  // TODO: fix act warning
   it('should be able to clear the input with ESC key when something is typed', () => {
     renderComponent({ graphqlMocks: [simpleSuggestions] })
 
@@ -124,19 +124,15 @@ describe('Location Search', () => {
   })
 
   it('should display failure message when the search term is not found', async () => {
-    jest.useFakeTimers()
-
     renderComponent({ graphqlMocks: [noSuggestions] })
 
     const input = screen.getByLabelText(LABEL_MATCHER)
 
     fireEvent.change(input, { target: { value: 'asdfasdfasdf' } })
 
-    act(() => {
-      jest.runAllTimers()
+    await waitFor(() => {
+      expect(screen.queryByText('No results found')).toBeInTheDocument()
     })
-
-    expect(screen.queryByText('No results found')).toBeInTheDocument()
   })
 
   it('should render provider logo', async () => {

--- a/react/package.json
+++ b/react/package.json
@@ -24,14 +24,14 @@
     "@vtex/test-tools": "^3.0.2",
     "apollo-cache-inmemory": "^1.6.6",
     "apollo-client": "^2.6.10",
-    "vtex.address-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.address-context@0.5.0/public/@types/vtex.address-context",
+    "vtex.address-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.address-context@0.6.1/public/@types/vtex.address-context",
     "vtex.checkout-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-components@0.5.1/public/@types/vtex.checkout-components",
-    "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.55.1/public/@types/vtex.checkout-graphql",
+    "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.56.1/public/@types/vtex.checkout-graphql",
     "vtex.country-flags": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.country-flags@0.1.1/public/@types/vtex.country-flags",
     "vtex.geolocation-graphql-interface": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.geolocation-graphql-interface@0.3.0/public/@types/vtex.geolocation-graphql-interface",
     "vtex.places-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.places-graphql@0.4.0/public/@types/vtex.places-graphql",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.5/public/@types/vtex.render-runtime",
-    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.134.1/public/@types/vtex.styleguide"
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.11/public/@types/vtex.render-runtime",
+    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.135.2/public/@types/vtex.styleguide"
   },
   "jest": {
     "setupFilesAfterEnv": [

--- a/react/package.json
+++ b/react/package.json
@@ -15,6 +15,8 @@
   "devDependencies": {
     "@apollo/react-testing": "^3.1.3",
     "@reach/listbox": "^0.10.2",
+    "@testing-library/dom": "^7.29.5",
+    "@testing-library/user-event": "^12.7.1",
     "@types/classnames": "^2.2.7",
     "@types/jest": "^26.0.8",
     "@types/node": "^12.7.5",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5884,17 +5884,17 @@ vtex-tachyons@^3.2.0:
   resolved "https://registry.yarnpkg.com/vtex-tachyons/-/vtex-tachyons-3.2.2.tgz#e9e39d939778ef7d80a92c476cecf7417f79a6e8"
   integrity sha512-4M53uuvV+2XEjplVYiPgpBuaI5dtGksVgz/20NNjbZkXklJM7Lwgod/hOoh3PtIn36+95zZVVgXYfs3e6EU8YA==
 
-"vtex.address-context@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.address-context@0.5.0/public/@types/vtex.address-context":
-  version "0.5.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.address-context@0.5.0/public/@types/vtex.address-context#3f984bc73fba901d1c7dbdcebea8d29c7bc450e9"
+"vtex.address-context@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.address-context@0.6.1/public/@types/vtex.address-context":
+  version "0.6.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.address-context@0.6.1/public/@types/vtex.address-context#7d636645e335353fa277f52e3f808e4f2d01462b"
 
 "vtex.checkout-components@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-components@0.5.1/public/@types/vtex.checkout-components":
   version "0.5.1"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-components@0.5.1/public/@types/vtex.checkout-components#77d654aea75319f3024612fe7b263777b116105f"
 
-"vtex.checkout-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.55.1/public/@types/vtex.checkout-graphql":
-  version "0.55.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.55.1/public/@types/vtex.checkout-graphql#a9f282941d74fffac3d3d877d92313dd755de07f"
+"vtex.checkout-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.56.1/public/@types/vtex.checkout-graphql":
+  version "0.56.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.56.1/public/@types/vtex.checkout-graphql#c1153ec5faf232f92abfe495f867019bfb7d510f"
 
 "vtex.country-flags@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.country-flags@0.1.1/public/@types/vtex.country-flags":
   version "0.1.1"
@@ -5908,13 +5908,13 @@ vtex-tachyons@^3.2.0:
   version "0.4.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.places-graphql@0.4.0/public/@types/vtex.places-graphql#19d8522f344c82c677b474829deb629583def399"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.5/public/@types/vtex.render-runtime":
-  version "8.126.5"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.5/public/@types/vtex.render-runtime#f529e960313579c39a9748820885b995f9d6d3e6"
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.11/public/@types/vtex.render-runtime":
+  version "8.126.11"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.11/public/@types/vtex.render-runtime#aceb734766093b56954ec19a074574b4c2c95242"
 
-"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.134.1/public/@types/vtex.styleguide":
-  version "9.134.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.134.1/public/@types/vtex.styleguide#7210ed4908f4e6482d2499d71c4cfcc21e3dfd6a"
+"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.135.2/public/@types/vtex.styleguide":
+  version "9.135.2"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.135.2/public/@types/vtex.styleguide#bed07ae468480d4c5f2b8f65d46e72d452936f80"
 
 w3c-hr-time@^1.0.1:
   version "1.0.2"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -1397,6 +1397,20 @@
     lz-string "^1.4.4"
     pretty-format "^26.6.2"
 
+"@testing-library/dom@^7.29.5":
+  version "7.29.5"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.29.5.tgz#976d5a115c558a71bc688f1895922a5bdded2dc8"
+  integrity sha512-0PPIYHWkMZpwTSvSOHG4LfYQUeICcQEmXdjINCnJ/4v04iTKG71SS2jj+fg8bNP5nq/ppKPRgwDQsdByQg278Q==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^4.2.2"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.4"
+    lz-string "^1.4.4"
+    pretty-format "^26.6.2"
+
 "@testing-library/jest-dom@^5.11.2":
   version "5.11.6"
   resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.11.6.tgz#782940e82e5cd17bc0a36f15156ba16f3570ac81"
@@ -1426,6 +1440,13 @@
   dependencies:
     "@babel/runtime" "^7.10.3"
     "@testing-library/dom" "^7.22.3"
+
+"@testing-library/user-event@^12.7.1":
+  version "12.7.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-12.7.1.tgz#e1ce931c04a1c65faf28618442d56ba8da887f2c"
+  integrity sha512-COfCkYgcxc+P9+pEAIGlmBuIDjO91Chf9GOBHI8AhIiMyaoOrKVPQny1uf0HIAYNoHKL5slhkqOPP2ZyNaVQGw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 "@types/aria-query@^4.2.0":
   version "4.2.0"


### PR DESCRIPTION
#### What problem is this solving?

When inserting a postal code in the `LocationInput` component...

1. no error state appear, even with an wrongly formatted postal code
2. when submitting an invalid postal code for the second time in a row, the component loads indefinitely

#### How should this be manually tested?

[Workspace](https://postalcode--checkoutio.myvtex.com/cart/add?sku=312&sc=2)

First scenario (see the **screenshot** bellow):
1. select Brazil in the country combobox
2. insert the "22250-04" postal code and submit (obs: it's missing the last digit)
3. it should display an error message _immediately_

Second scenario (see the **video** bellow):
1. select USA in the country combobox
2. insert the "asdf" postal code and submit
3. it should display an error message
4. delete the last character, re-add it and submit
5. it should display an error message, instead of loading indefinitely

Obs: the reason why you should test the second scenario with USA is because this country still don't have a validation pattern for the front-end, so the component does not block the submission button right away - it consults the back-end instead.

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Jira story (if applicable).
- [x] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/26108090/108114276-fdb2d080-706e-11eb-88ff-189c187e2b8b.png)

https://user-images.githubusercontent.com/26108090/108114818-a82af380-706f-11eb-96ab-7cc8396c7679.mov