### PR TITLE
CHK-568: Add optional custom address prop to place details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `PlaceDetails` allows the usage of a custom address.
 
 ## [0.14.2] - 2021-02-26
 ### Changed
-- All components request country information in a standardiezed way.
+- All components request country information in a standardized way.
 - Typings were updated to match original types.
 
 ## [0.14.1] - 2021-02-23

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ Country data is sorted according to [Figma designs](https://www.figma.com/file/u
 
 ## Place Details
 
-The Place Details component displays a summary of a place according to the address it receives from the wrapper orchestrator, and the description of the structure that receives as prop. There are three variations of PlaceDetails according to the amount of information that needs to be shown in a particular scenario. Below you can see a description of them.
+The Place Details component displays a summary of a place according to the address from the wrapper orchestrator or a custom address passed via props. There are three variations of PlaceDetails according to the amount of information that needs to be shown in a particular scenario. Below you can see a description of them.
 
 - **Extended**: complete address, with all information that's necessary for carriers and users to identify it.
 - **Compact**: displays details gathered through LocationForm or from its info.

--- a/react/PlaceDetails.tsx
+++ b/react/PlaceDetails.tsx
@@ -5,6 +5,7 @@ import { AddressFields } from 'vtex.address-context/types'
 import { ButtonPlain } from 'vtex.styleguide'
 import { useIntl, defineMessages } from 'react-intl'
 import { DisplayData } from 'vtex.country-data-settings'
+import { Address } from 'vtex.checkout-graphql'
 
 import { FieldName } from './useAddressForm'
 import { useCountry } from './useCountry'
@@ -13,6 +14,7 @@ interface Props {
   display?: keyof Omit<DisplayData, '__typename'>
   hiddenFields?: AddressFields[]
   onEdit?: () => void
+  customAddress?: Address
 }
 
 const messages = defineMessages({
@@ -26,8 +28,10 @@ const PlaceDetails: React.FC<Props> = ({
   display = 'extended',
   hiddenFields = [],
   onEdit,
+  customAddress,
 }) => {
-  const { address, rules } = useAddressContext()
+  const { address: contextAddress, rules } = useAddressContext()
+  const address = customAddress ?? contextAddress
   const country = useCountry()
   const countryRules = rules[country]
 


### PR DESCRIPTION
#### What problem is this solving?

Sometimes we might want to render the details of places that aren't from the user, like for pickup store. Now it's also possible to use place details inside address list, if we want to.

#### How should this be manually tested?

Same as https://github.com/vtex-apps/checkout-shipping/pull/31
